### PR TITLE
windowsのホストだと退役がご検知される

### DIFF
--- a/lib/malsh/cli.rb
+++ b/lib/malsh/cli.rb
@@ -15,9 +15,9 @@ module Malsh
     def retire
       Malsh.init options
 
-      host_names = Parallel.map(Malsh.metrics('loadavg5')) do|lvg|
-        host = Malsh.host_by_id lvg.first
-        host.name if (!lvg.last.loadavg5.respond_to?(:value) || !lvg.last.loadavg5.value)
+      host_names = Parallel.map(Malsh.metrics('memory.used')) do|memory|
+        host = Malsh.host_by_id memory.first
+        host.name if (!memory.last["memory.used"].respond_to?(:value) || !memory.last["memory.used"].value)
       end.flatten.compact
 
       Malsh.notify("退役未了ホスト一覧", host_names)

--- a/spec/lib/malsh/cli_spec.rb
+++ b/spec/lib/malsh/cli_spec.rb
@@ -10,8 +10,8 @@ describe Malsh::CLI do
     describe '.#retire' do
       before do
         allow(Malsh).to receive(:metrics).and_return([
-            [1, double(loadavg5: nil)],
-            [2, double(loadavg5: double(value: 1))],
+          [1, "memory.used" => nil],
+          [2, "memory.used" => double(value: 1)],
         ])
         allow(Mackerel).to receive(:hosts).and_return([
           double(id: 1, name: "retire_host", displayName: nil),


### PR DESCRIPTION
windowsホストの場合、ロードアベレージが取得できず、誤って退役漏れ扱いされるので修正した。
