### PR TITLE
add option invert role

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ $ malsh search --past_date 7 --cpu 40 --memory 40 --subject 過去7日間のCPU�
  * 除外したいホスト名を正規表現で指定します。
 * --regex
  * 特定したいホスト名を正規表現で指定します。
+* --invert-role
+ * 除外したいロール名を`service:role`で指定します。
 
 ## Author
 pyama86

--- a/lib/malsh.rb
+++ b/lib/malsh.rb
@@ -35,6 +35,11 @@ module Malsh
         Malsh.options[:invert_match] && Malsh.options[:invert_match].find {|v| host_name(h).match(/#{v}/) }
       end.reject do |h|
         Malsh.options[:regexp] && Malsh.options[:regexp].all? {|r| !host_name(h).match(/#{r}/)}
+      end.reject do |h|
+        Malsh.options[:invert_role] && Malsh.options[:invert_role].find do |r|
+          service, role = r.split(/:/)
+          h.roles[service] && h.roles[service].include?(role)
+        end
       end
     end
 

--- a/lib/malsh/cli.rb
+++ b/lib/malsh/cli.rb
@@ -9,6 +9,7 @@ module Malsh
     class_option :api_key, :type => :string, :aliases => :k
     class_option :subject, :type => :string, :aliases => :s
     class_option :invert_match, :type => :array, :aliases => :v
+    class_option :invert_role, :type => :array, :aliases => :r
     class_option :regexp,:type => :array, :aliases => :e
 
     desc 'retire', 'check forget retire host'

--- a/spec/lib/malsh/cli_spec.rb
+++ b/spec/lib/malsh/cli_spec.rb
@@ -127,10 +127,10 @@ describe Malsh::CLI do
   context 'options' do
     before do
       allow(Mackerel).to receive(:hosts).and_return([
-        double(id: 1, name: "develop_host", displayName: nil, :[] => "develop_host"),
-        double(id: 2, name: "host_local", displayName: nil, :[] => "host_local"),
-        double(id: 3, name: "local_host", displayName: nil, :[] => "loal_host"),
-        double(id: 4, name: "production_host", displayName: nil, :[] => "production_host")
+        double(id: 1, name: "develop_host", displayName: nil, :[] => "develop_host", roles: {"example" => ["bar"]}),
+        double(id: 2, name: "host_local", displayName: nil, :[] => "host_local", roles: {"example" => ["bar"]}),
+        double(id: 3, name: "local_host", displayName: nil, :[] => "loal_host", roles: {"example" => ["bar"]}),
+        double(id: 4, name: "production_host", displayName: nil, :[] => "production_host", roles: {"example" => ["foo"]})
       ])
     end
 
@@ -158,6 +158,15 @@ describe Malsh::CLI do
       it {
         is_expected.to be_truthy
         expect(Malsh::Notification::Base).to have_received(:notify).with("ホスト一覧", ["develop_host"])
+      }
+    end
+
+    describe 'invert_role' do
+      subject { Malsh::CLI.new.invoke(:search, [], {invert_role: ["example:foo"]}) }
+
+      it {
+        is_expected.to be_truthy
+        expect(Malsh::Notification::Base).to have_received(:notify).with("ホスト一覧", ["develop_host", "host_local", "loal_host"])
       }
     end
   end


### PR DESCRIPTION
It was to be excluded in the role name

```
malsh serarch -r <service>:<role>
```
