### PR TITLE
slack通知時にホストの設定画面へのリンクを追加した

### DIFF
--- a/lib/malsh/notification/base.rb
+++ b/lib/malsh/notification/base.rb
@@ -1,7 +1,8 @@
 module Malsh::Notification
   class Base
     def self.notify(subject, hosts)
-      puts "#{subject}: \n#{hosts.join("\n")}" if hosts.size > 0 && doit?
+      names = hosts.map(&:name)
+      puts "#{subject}: \n#{names.join("\n")}" if names.size > 0 && doit?
     end
 
     def self.doit?

--- a/lib/malsh/notification/slack.rb
+++ b/lib/malsh/notification/slack.rb
@@ -3,8 +3,15 @@ module Malsh::Notification
   class Slack < Base
     def self.notify(subject, hosts)
       return unless doit?
+      lists = if Malsh.options[:org]
+                hosts.map do |h|
+                  "<https://mackerel.io/orgs/#{Malsh.options[:org]}/hosts/#{h.id}/-/setting|#{h.name}>"
+                end
+              else
+                hosts.map(&:name)
+              end
       note = {
-        text: hosts.join("\n"),
+        text: lists.join("\n"),
         color: "warning"
       }
       notifier.ping "*#{subject}*", attachments: [note]

--- a/spec/lib/malsh/cli_spec.rb
+++ b/spec/lib/malsh/cli_spec.rb
@@ -7,47 +7,6 @@ describe Malsh::CLI do
   end
 
   context 'basic' do
-    describe '.#retire' do
-      before do
-        allow(Malsh).to receive(:metrics).and_return([
-          [1, "memory.used" => nil],
-          [2, "memory.used" => double(value: 1)],
-        ])
-        allow(Mackerel).to receive(:hosts).and_return([
-          double(id: 1, name: "retire_host", displayName: nil),
-          double(id: 2, name: "enable_host", displayName: nil),
-        ])
-        allow(Mackerel).to receive(:host).with(1).and_return(
-          double(id: 1, name: "retire_host", displayName: nil),
-        )
-        allow(Mackerel).to receive(:host).with(2).and_return(
-          double(id: 1, name: "retire_host", displayName: nil),
-        )
-      end
-      subject { Malsh::CLI.new.invoke(:retire, [], {}) }
-
-      it {
-        is_expected.to be_truthy
-        expect(Malsh::Notification::Base).to have_received(:notify).with("退役未了ホスト一覧", ["retire_host"])
-      }
-    end
-
-
-    describe '.#maverick' do
-      before do
-        allow(Mackerel).to receive(:hosts).and_return([
-          double(id: 1, name: "have_role_host", displayName: nil, roles: {test: 1}),
-          double(id: 2, name: "maverick_host", displayName: nil, roles: {})
-        ])
-      end
-      subject { Malsh::CLI.new.invoke(:maverick, [], {}) }
-
-      it {
-        is_expected.to be_truthy
-        expect(Malsh::Notification::Base).to have_received(:notify).with("ロール無所属ホスト一覧", ["maverick_host"])
-      }
-    end
-
     describe '.#search' do
       before do
         allow(Mackerel).to receive(:hosts).and_return([
@@ -99,7 +58,7 @@ describe Malsh::CLI do
 
           it 'lower threshold' do
             is_expected.to be_truthy
-            expect(Malsh::Notification::Base).to have_received(:notify).with("ホスト一覧", ["example_host"])
+            expect(Malsh::Notification::Base).to have_received(:notify).with("ホスト一覧", [{"id"=>1, "name"=>"example_host", "meta"=>{"cpu"=>[0, 1]}}])
           end
         end
       end
@@ -121,53 +80,6 @@ describe Malsh::CLI do
         let(:resources) { %w(cpu.user.percentage cpu.iowait.percentage cpu.system.percentage memory.used memory.cached memory.total) }
         it_behaves_like 'resource_check'
       end
-    end
-  end
-
-  context 'options' do
-    before do
-      allow(Mackerel).to receive(:hosts).and_return([
-        double(id: 1, name: "develop_host", displayName: nil, :[] => "develop_host", roles: {"example" => ["bar"]}),
-        double(id: 2, name: "host_local", displayName: nil, :[] => "host_local", roles: {"example" => ["bar"]}),
-        double(id: 3, name: "local_host", displayName: nil, :[] => "loal_host", roles: {"example" => ["bar"]}),
-        double(id: 4, name: "production_host", displayName: nil, :[] => "production_host", roles: {"example" => ["foo"]})
-      ])
-    end
-
-    describe 'subject' do
-      subject { Malsh::CLI.new.invoke(:search, [], {regexp: ["dev"], subject: "subject"}) }
-
-      it {
-        is_expected.to be_truthy
-        expect(Malsh::Notification::Base).to have_received(:notify).with("subject", ["develop_host"])
-      }
-    end
-
-    describe 'regexp' do
-      subject { Malsh::CLI.new.invoke(:search, [], {regexp: ["dev", "local$"]}) }
-
-      it {
-        is_expected.to be_truthy
-        expect(Malsh::Notification::Base).to have_received(:notify).with("ホスト一覧", ["develop_host", "host_local"])
-      }
-    end
-
-    describe 'invert_match' do
-      subject { Malsh::CLI.new.invoke(:search, [], {regexp: ["dev", "local$"], invert_match: ["host_local"]}) }
-
-      it {
-        is_expected.to be_truthy
-        expect(Malsh::Notification::Base).to have_received(:notify).with("ホスト一覧", ["develop_host"])
-      }
-    end
-
-    describe 'invert_role' do
-      subject { Malsh::CLI.new.invoke(:search, [], {invert_role: ["example:foo"]}) }
-
-      it {
-        is_expected.to be_truthy
-        expect(Malsh::Notification::Base).to have_received(:notify).with("ホスト一覧", ["develop_host", "host_local", "loal_host"])
-      }
     end
   end
 end


### PR DESCRIPTION
slack通知時にホスト名のリンクに設定画面へのリンクを追加しました。利用するにはオプションに`-o <org>`を指定する必要があります。