### PR TITLE
"service" type alert has no host

### DIFF
--- a/lib/malsh.rb
+++ b/lib/malsh.rb
@@ -51,10 +51,10 @@ module Malsh
 
     def alerts()
       @_alerts ||= Mackerel.alerts.map do |alert|
-        if alert.type == 'external'
-          alert['monitor'] = Mackerel.monitor(alert.monitorId)
-        else
+        if alert_has_host?(alert)
           alert['host'] = Malsh.host_by_id(alert.hostId)
+        else
+          alert['monitor'] = Mackerel.monitor(alert.monitorId)
         end
         alert
       end
@@ -90,6 +90,12 @@ module Malsh
       rescue => e
         puts e
       end
+    end
+
+    def alert_has_host?(alert)
+      exclude_types = ['external', 'service']
+      return false if exclude_types.include?(alert.type)
+      true
     end
   end
 end

--- a/lib/malsh/notification/slack.rb
+++ b/lib/malsh/notification/slack.rb
@@ -30,16 +30,16 @@ module Malsh::Notification
                   ''
                 end
 
-        title = if alert.type == 'external'
-                  alert.monitor.name
-                else
+        title = if Malsh.alert_has_host?(alert)
                   alert.host.name
+                else
+                  alert.monitor.name
                 end
 
-        author_name = if alert.type == 'external'
-                        ''
-                      else
+        author_name = if Malsh.alert_has_host?(alert)
                         alert.host.roles.map{|k, v| v.map{|r| "#{k}: #{r}"}}.flatten.join(" ")
+                      else
+                        ''
                       end
 
         attachments << {


### PR DESCRIPTION
Hi @pyama86.

"service" type alert has no host information like as "external" type.

What do you think about this change?